### PR TITLE
Fixed Django App Migration and Installation

### DIFF
--- a/Rekognition/settings.py
+++ b/Rekognition/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
-    'cceface.apps.CcefaceConfig',
     'django.contrib.staticfiles',
     'rest_framework',
     'coreapi',

--- a/Rekognition/urls.py
+++ b/Rekognition/urls.py
@@ -22,8 +22,6 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     path('api/', include('coreapi.urls')),
-    path('', include("cceface.urls")),
-
 ]
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/corelib/constant.py
+++ b/corelib/constant.py
@@ -4,8 +4,6 @@ from corelib.facenet.align import detect_face
 import tensorflow as tf
 import os
 
-
-upload_path = os.path.join(BASE_DIR, 'cceface/uploads')
 embeddings_path = os.path.join(BASE_DIR, 'corelib/embeddings')
 allowed_set = set(['png', 'jpg', 'jpeg', 'PNG', 'JPEG', 'JPG'])
 facenet_model_path = BASE_DIR + '/corelib/model/facenet/2017/20170512-110547.pb'

--- a/manage.sh
+++ b/manage.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env sh
-rm cceface/migrations/*.py
-rm cceface/migrations/*.pyc
-touch cceface/migrations/__init__.py
 python manage.py makemigrations
 python manage.py migrate


### PR DESCRIPTION
## Issue 

Fixes https://github.com/npbit/Rekognition/issues/117

## Description 

While installing the Django Application, I ran into an issue which was unexpected. While consulting with the Project Mentor @PulkitMishra I found that this was because `cceface` is no longer being used and deprecated. 

This was a critical issue since it would hinder new contributors, to get started contributed. I removed any references to `cceface` from the Project. 

I also noticed that the Travis CI Test still uses, tests from the `cceface` directory which no longer exists. Would it be fit, if I remove it as well? 

Here are some Screenshots to show that the Django App is working again: 

![image](https://i.imgur.com/qnAEsY2.png)

![image](https://i.imgur.com/VCZM9fG.png)